### PR TITLE
QA: Tests for 'generate dadada' Feature

### DIFF
--- a/src/components/Landing/FeaturesSection/FeaturesSection.test.tsx
+++ b/src/components/Landing/FeaturesSection/FeaturesSection.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FeaturesSection } from './FeaturesSection';
+
+describe('FeaturesSection Component', () => {
+  it('should render the Generate Dadada feature card', () => {
+    render(<FeaturesSection />);
+    const featureTitle = screen.getByText('Generate Dadada');
+    expect(featureTitle).toBeInTheDocument();
+
+    const featureDescription = screen.getByText(
+      "Experience the magic of AI-generated music with our 'Generate Dadada' feature. Create unique soundscapes effortlessly."
+    );
+    expect(featureDescription).toBeInTheDocument();
+  });
+});

--- a/src/i18n/request.test.ts
+++ b/src/i18n/request.test.ts
@@ -1,0 +1,16 @@
+import getRequestConfig from './request';
+import { routing } from './routing';
+
+describe('i18n Request Configuration', () => {
+  it('should load locale messages for the default locale when an unsupported locale is provided', async () => {
+    const config = await getRequestConfig({ requestLocale: 'unsupported' });
+    expect(config.locale).toBe(routing.defaultLocale);
+  });
+
+  it('should correctly set the locale to dadada if provided', async () => {
+    const config = await getRequestConfig({ requestLocale: 'dadada' });
+    expect(config.locale).toBe('dadada');
+    const messages = config.messages;
+    expect(messages).toBeDefined();
+  });
+});


### PR DESCRIPTION
### Validation Summary
This PR adds test coverage for the `FeaturesSection` component and the `i18n` request configuration to ensure accurate and reliable presentation and support for the 'Generate Dadada' feature.

### Regression Risks
- Potential incorrect UI rendering of the feature.
- `i18n` configuration might not handle unsupported locales correctly.

### Test Coverage Rationale
Tests were added for the `FeaturesSection` to verify that the UI elements specific to the 'Generate Dadada' feature are rendered as expected. Additionally, `i18n` request tests ensure locale handling is accurate, specifically for the new 'dadada' locale.

### Files Created
- `src/components/Landing/FeaturesSection/FeaturesSection.test.tsx`: Tests that verify the rendering of the 'Generate Dadada' feature card.
- `src/i18n/request.test.ts`: Tests to ensure the 'dadada' locale is correctly supported and fallback logic works.

This PR addresses the necessary quality gate by adding tests to ensure the stability and correctness of the new feature implementation.

Testing these aspects helps ensure feature integrity and prepares the codebase for future enhancements without regressions.
